### PR TITLE
Reenable format option

### DIFF
--- a/lib/router/router-defaults.js
+++ b/lib/router/router-defaults.js
@@ -33,10 +33,10 @@ module.exports = {
       ax: 'anchorX',
       ay: 'anchorY'
     },
-    /*fm: {
+    fm: {
       name: 'format',
       f: 'format'
-    },*/
+    },
     qt: {
       name: 'quality',
       q: 'quality'


### PR DESCRIPTION
Hi verified that image format option was disabled in a shaper upgrade commit.

Is there any special reason for it? 

I propose reenabled it. I understand that for most of cases it is not necessary, but it can be interesting in special case and it already built.
