### PR TITLE
Just forward image if no operation and browser supports the format 

### DIFF
--- a/lib/router/router.js
+++ b/lib/router/router.js
@@ -4,6 +4,23 @@ var EventEmitter = require('events').EventEmitter;
 var helpers = require('../helpers');
 var defaults = require('./router-defaults');
 
+var imageContentTypes = {
+  'image/png': {
+    pathRegEx: /\.png$/,
+    acceptRegEx: /image\/png|\*\/\*/
+  },
+  'image/jpeg': {
+    pathRegEx: /\.jpg$/,
+    acceptRegEx: /image\/jpeg|\*\/\*/
+  },
+  'image/git': {
+    pathRegEx: /\.git$/,
+    acceptRegEx: /image\/git|\*\/\*/
+  }
+};
+
+var imageContentTypeKeys = Object.keys(imageContentTypes);
+
 var otherContentTypes = {
   'text/css': {
     pathRegEx: /\.css$/,
@@ -109,6 +126,15 @@ p.getInfo = function(req) {
     }
   }
 
+  // forward original image if no operation on image and browser support image format
+  if (routeInfo.imageSteps.length === 0 && this.options.ifNoOperation && this.options.ifNoOperation.justForward === true) {
+    contentType = getImageContentType(req,routeInfo,this.options.ifNoOperation.imageTypeIfUnknown);
+    if (contentType) {
+      routeInfo.contentType = contentType;
+      return routeInfo;
+    }
+  }
+
   if (routeInfo.imageSteps.filter(filterFormat).length === 0) {
     if (routeInfo.urlInfo.query.download !== undefined
       || routeInfo.imageSteps.filter(filterProgressive).length > 0) {
@@ -172,6 +198,20 @@ p.getStepsFromObject = function(obj) {
 
   return steps;
 };
+
+function getImageContentType(req, routeInfo, contentTypeIfUnknown) {
+  var acceptsHeader = req.headers.accept;
+  for (var i = 0; i < imageContentTypeKeys.length; i++) {
+    var contentType = imageContentTypeKeys[i];
+    var ctInfo = imageContentTypes[contentType];
+    console.log(contentType);
+    if (ctInfo.pathRegEx.test(routeInfo.urlInfo.pathname) && (!ctInfo.acceptRegEx || !acceptsHeader || ctInfo.acceptRegEx.test(acceptsHeader))) {
+      return contentType; // NOT an image, track as explicit content type
+    }
+  }
+  var ctInfoIfUnknown = imageContentTypes[contentTypeIfUnknown];
+  if ( ctInfoIfUnknown && (!acceptsHeader || ctInfoIfUnknown.acceptRegEx.test(acceptsHeader))) return contentTypeIfUnknown;
+}
 
 function getContentType(req, routeInfo) {
   var acceptsHeader = req.headers.accept;

--- a/lib/storage/fs/index.js
+++ b/lib/storage/fs/index.js
@@ -1,5 +1,5 @@
 var path = require('path');
-var fs = require('fs');
+var fs = require('fs-extra');
 var _ = require('lodash');
 var StorageBase = require('../storage-base');
 
@@ -34,6 +34,24 @@ p.fetch = function(options, originalPath, stepsHash, cb) {
   });
 };
 
+
+function checkDir(filename, cb) {
+  var folder = path.dirname(filename);
+  fs.stat(folder, function(err, data) {
+    if(!err) return cb();
+    if(err.code === 'ENOENT') {
+      fs.mkdirp(folder, function(err){
+        if (err) {
+          return void cb(err);
+        }
+        cb();
+      });
+    } else {
+      return void cb(err);
+    }
+  });
+}
+
 p.store = function(options, originalPath, stepsHash, image, cb) {
   var filename = originalPath;
   if (!stepsHash) {
@@ -44,8 +62,14 @@ p.store = function(options, originalPath, stepsHash, image, cb) {
 
   image.info.stepsHash = stepsHash;
 
-  fs.writeFile(filename + '.json', new Buffer(JSON.stringify(image.info)), 'utf8', function(err) {
-    // do nothing
+  checkDir(filename, function(err){
+    if (err) {
+      return void cb(err);
+    }
+    fs.writeFile(filename + '.json', new Buffer(JSON.stringify(image.info)), 'utf8', function(err) {
+      // do nothing
+    });
+    fs.writeFile(filename, image.buffer, cb);
+
   });
-  fs.writeFile(filename, image.buffer, cb);
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "image-steam",
-  "version": "0.31.2",
+  "version": "0.31.3",
   "description": "A simple, fast, and highly customizable on-the-fly image manipulation web server built atop Node.js.",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
   },
   "dependencies": {
     "async": "^2.0.0",
+    "fs-extra": "^0.30.0",
     "knox": "0.9.2",
     "lodash": "^3.10.1",
     "optimist": "0.6.1",


### PR DESCRIPTION
The images are processed even if there is no operation.
This behavior seems good since if browser supports WEBP you can safe bandwidth sending image in a more compressed format.
But for some applications it can waste CPU and storage resources.
I added an option in router options to enable to just forward the content if no operation is required.
Content-type is defined based on path and you can define a type to use if type can not be defined using the path.
If the browser seems to do not support the original type it do not forward it and keep the same flow than before.
The router option goes as:
  router: {
    ifNoOperation: {
      justForward: true,
      imageTypeIfUnknown: 'image/jpeg'
    }
  }
